### PR TITLE
Allow to customize error message via `errorMessage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ export default reduxForm({
 })(YourForm)
 ```
 
+## Customize error message via `errorMessage` option
+
+You can use `errorMessage` option to pass function that will receive `ajv` error object as argument and should return error message.
+
+```javascript
+import validate from 'redux-form-with-ajv'
+
+const errorMessage = (_error) => {
+  if (_error.keyword === 'required') {
+    return 'is required'
+  }
+
+  return _error.message
+}
+
+export default reduxForm({
+  form: 'yourForm',
+  validate: validate(yourJsonSchema, { errorMessage })
+})(YourForm)
+```
+
 ## Run examples
 
 ### Simple validation with few Field(s)

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,10 @@ const ajvOptions = {
 const ajvErrorsOptions = { keepErrors: false };
 const ajvWithErrors = new AjvErrors(new Ajv(ajvOptions), ajvErrorsOptions);
 
+const errorMessage = (_error) => (_error.message);
+
 export default (schema, options = {}) => {
-  options = objectAssign({ ajv: ajvWithErrors }, options);
+  options = objectAssign({ ajv: ajvWithErrors, errorMessage }, options);
 
   return values => {
     const errors = {};
@@ -33,7 +35,7 @@ export default (schema, options = {}) => {
           fullPath += '._error';
         }
 
-        const message = _error.message;
+        const message = options.errorMessage(_error);
 
         objectPath.set(errors, fullPath, message);
       });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -31,6 +31,38 @@ describe('redux-form-with-ajv', () => {
     expect(validateSpy).to.have.been.called.with(values);
   });
 
+  it('should allow to customize error messages via option function', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name1: {
+          type: 'string'
+        },
+        name2: {
+          type: 'string'
+        }
+      },
+      required: ['name1', 'name2']
+    };
+
+    const errorMessage = (_error) => {
+      if (_error.keyword === 'required' && _error.params.missingProperty === 'name2') {
+        return 'is required'
+      }
+
+      return _error.message;
+    }
+
+    const errors = validate(schema, { errorMessage })({});
+
+    const expectedError = {
+      name1: "should have required property 'name1'",
+      name2: "is required"
+    };
+
+    expect(expectedError).to.deep.equal(errors);
+  });
+
   describe('when schema is valid', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
You can use `errorMessage` option to pass function that will receive `ajv` error object as argument and should return error message.

```javascript
import validate from 'redux-form-with-ajv'

const errorMessage = (_error) => {
  if (_error.keyword === 'required') {
    return 'is required'
  }

  return _error.message
}

export default reduxForm({
  form: 'yourForm',
  validate: validate(yourJsonSchema, { errorMessage })
})(YourForm)
```

I know it's possible to use https://github.com/epoberezkin/ajv-errors for custom error messages, but you need to define messages in every schama and with this option you can have on function that will "translate" error objects to error messages. 
